### PR TITLE
#64 [json-rules-engine] TypeError after rules are evaluated: "forEach is not a function"

### DIFF
--- a/src/rulesRunner.js
+++ b/src/rulesRunner.js
@@ -8,7 +8,15 @@ function doRunRules(engine, formData, schema, uiSchema, extraActions = {}) {
   let uiSchemaCopy = deepcopy(uiSchema);
   let formDataCopy = deepcopy(formData);
 
-  let res = engine.run(formData).then((events) => {
+  let res = engine.run(formData).then(result => {
+    let events;
+    if (Array.isArray(result)) {
+      events = result;
+    } else if (typeof result === 'object' && result.events && Array.isArray(result.events)) {
+      events = result.events;
+    } else {
+      throw new Error("Unrecognized result from rules engine");
+    }
     events.forEach((event) =>
       execute(event, schemaCopy, uiSchemaCopy, formDataCopy, extraActions)
     );

--- a/test/issues/64.test.js
+++ b/test/issues/64.test.js
@@ -1,0 +1,59 @@
+import React from "react";
+import Form from "@rjsf/core";
+import Engine from "json-rules-engine";
+import applyRules from "../../src";
+
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+
+const rules = [
+  {
+    "conditions": {
+      "any": [
+        {
+          "fact": "name",
+          "operator": "equal",
+          "value": "truthy"
+        }
+      ]
+    },
+    "event": {
+      "type": "log",
+      "params": {
+        "foo": "bar"
+      }
+    }
+  }
+];
+
+const schema = {
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  }
+};
+
+const extraActions = {
+  log: (params, schema, uiSchema, formData) => {
+    console.log(params, schema, uiSchema, formData);
+  }
+};
+
+test("json-rules-engine must not throw when rendering form", () => {
+
+  const FormWithConditionals = applyRules(
+    schema,
+    { },
+    rules,
+    Engine,
+    extraActions
+  )(Form);
+
+  const { container } = render(<FormWithConditionals formData={{ name: "foo" }} />);
+  const name = container.querySelector("[id='root_name']");
+  expect(name).not.toBeNull();
+
+});


### PR DESCRIPTION
Since json-rules-engine@4.0.0 Engine.run resolves to an Object with a property events instead of expected Array of events:
CacheControl/json-rules-engine@39aa362#diff-a90e3923c35433ee5931637e28ce9500